### PR TITLE
Dev/put in flashmem

### DIFF
--- a/src/sf22aswt_converter.cpp
+++ b/src/sf22aswt_converter.cpp
@@ -2,7 +2,7 @@
 
 namespace SF22ASWT::converter
 {
-    AudioSynthWavetable::instrument_data to_AudioSynthWavetable_instrument_data(SF22ASWT::instrument_data_temp &data)
+    CODE_LOCATION AudioSynthWavetable::instrument_data to_AudioSynthWavetable_instrument_data(SF22ASWT::instrument_data_temp &data)
     {
         // must use a second struct to contain the data
         // as AudioSynthWavetable::sample_data members are const
@@ -26,7 +26,7 @@ namespace SF22ASWT::converter
         };
     }
 
-    SF22ASWT::sample_header toFinal(SF22ASWT::sample_header_temp &sd)
+    CODE_LOCATION SF22ASWT::sample_header toFinal(SF22ASWT::sample_header_temp &sd)
     {
         return 
         {

--- a/src/sf22aswt_error_enums.cpp
+++ b/src/sf22aswt_error_enums.cpp
@@ -154,6 +154,7 @@ namespace SF22ASWT::Error
 
 namespace SF22ASWT
 {
+    using namespace SF22ASWT::Error;
 #ifdef SF22ASWT_PRINT_ERROR_CODE_AS_TEXT
     bool printError(Print &printStream, const uint16_t *lockupTable, const char * const *strings, int size, uint32_t code)
     {
@@ -187,27 +188,27 @@ namespace SF22ASWT
         uint32_t type = code & ERROR_TYPE_LOCATION_NIBBLE_MASK;
         uint32_t operation = code & ERROR_OPERATION_NIBBLE_MASK;
 
-        if (printError(RootLocation_LockupTable, RootLocation_Strings, RootLocation_LockupTable_Size, root))
+        if (printError(printStream,RootLocation_LockupTable, RootLocation_Strings, RootLocation_LockupTable_Size, root))
             printStream.print("_");
         
         // TODO the following should use the different lockup tables for each sub type list
         if (root == ((uint16_t)RootLocation::INFO)) {
-            if (printError(INFO_LockupTable, INFO_Strings, INFO_LockupTable_Size, sub))
+            if (printError(printStream,INFO_LockupTable, INFO_Strings, INFO_LockupTable_Size, sub))
                 printStream.print("_");
         } else if (root == ((uint16_t)RootLocation::SDTA)) {
-            if (printError(SDTA_LockupTable, SDTA_Strings, SDTA_LockupTable_Size, sub))
+            if (printError(printStream,SDTA_LockupTable, SDTA_Strings, SDTA_LockupTable_Size, sub))
                 printStream.print("_");
         } else if (root == ((uint16_t)RootLocation::PDTA)) {
-            if (printError(PDTA_LockupTable, PDTA_Strings, PDTA_LockupTable_Size, sub))
+            if (printError(printStream,PDTA_LockupTable, PDTA_Strings, PDTA_LockupTable_Size, sub))
                 printStream.print("_");
         } else if (root == ((uint16_t)RootLocation::FUNCTION)) {
-            if (printError(FUNCTION_LockupTable, FUNCTION_Strings, FUNCTION_LockupTable_Size, sub))
+            if (printError(printStream,FUNCTION_LockupTable, FUNCTION_Strings, FUNCTION_LockupTable_Size, sub))
                 printStream.print("_");
         }
-        if (printError(Type_LockupTable, Type_Strings, Type_LockupTable_Size, type))
+        if (printError(printStream,Type_LockupTable, Type_Strings, Type_LockupTable_Size, type))
             printStream.print("_");
         
-        printError(Operation_LockupTable, Operation_Strings, Operation_LockupTable_Size, operation);
+        printError(printStream,Operation_LockupTable, Operation_Strings, Operation_LockupTable_Size, operation);
 #endif
     }
 }

--- a/src/sf22aswt_error_enums.cpp
+++ b/src/sf22aswt_error_enums.cpp
@@ -351,7 +351,7 @@ namespace SF22ASWT::Error
     };
     int ErrorList_Size = sizeof(ErrorList) / sizeof(ErrorList[0]);
 
-    void PrintList(Print &printStream)
+    CODE_LOCATION void PrintList(Print &printStream)
     {
 
         printStream.print("Error count: "); printStream.print(ErrorList_Size-1); printStream.write('\n');

--- a/src/sf22aswt_error_enums.h
+++ b/src/sf22aswt_error_enums.h
@@ -4,10 +4,7 @@
 #define SF22ASWT_ERROR_ENUMS_H_
 
 #include <Arduino.h>
-
-// this mode takes 448 bytes of flash
-#define SF22ASWT_PRINT_ERROR_CODE_AS_TEXT
-
+#include "sf22aswt_settings.h"
 
 namespace SF22ASWT::Error
 {

--- a/src/sf22aswt_error_enums.h
+++ b/src/sf22aswt_error_enums.h
@@ -6,7 +6,7 @@
 #include <Arduino.h>
 
 // this mode takes 448 bytes of flash
-//#define SF22ASWT_PRINT_ERROR_CODE_AS_TEXT
+#define SF22ASWT_PRINT_ERROR_CODE_AS_TEXT
 
 
 namespace SF22ASWT::Error

--- a/src/sf22aswt_helpers.h
+++ b/src/sf22aswt_helpers.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
-
+#include "sf22aswt_settings.h"
 
 
 namespace Helpers

--- a/src/sf22aswt_reader.cpp
+++ b/src/sf22aswt_reader.cpp
@@ -3,7 +3,7 @@
 
 namespace SF22ASWT
 {
-    bool Reader::ReadFile(String filePath)
+    CODE_LOCATION bool Reader::ReadFile(String filePath)
     {
         File file = SD.open(filePath.c_str());
         if (!file) { lastError = SF22ASWT::Errors::FILE_NOT_OPEN; return false; }
@@ -68,7 +68,9 @@ namespace SF22ASWT
         file.close();
         return true;
     }
-    bool Reader::read_pdta_block(File &file)
+    
+    
+    CODE_LOCATION bool Reader::read_pdta_block(File &file)
     {
         char fourCC[4];
         uint32_t size = 0;

--- a/src/sf22aswt_reader_base.cpp
+++ b/src/sf22aswt_reader_base.cpp
@@ -266,7 +266,7 @@ namespace SF22ASWT
         return true;
     }
 
-#pragma region gen_get
+// #pragma region gen_get
     bool ReaderBase::get_parameter_value(bag_of_gens* bags, int sampleIndex, SFGenerator genType, SF2GeneratorAmount *amount)
     {
         bool globalExists = (bags[0].count != 0)?(bags[0].lastItem().sfGenOper != SFGenerator::sampleID):true;
@@ -387,13 +387,13 @@ namespace SF22ASWT
     void ReaderBase::DebugPrintBagContents(bag_of_gens &gen)
     {
         DebugPrint("bag contents:\n");
-#ifdef SF22ASWT_DEBUG
+ #ifdef SF22ASWT_DEBUG
         for (int i2=0;i2<gen.count;i2++)
         {
             DebugPrint_Text_Var("  sfGenOper:", (uint16_t)gen.items[i2].sfGenOper);
             DebugPrintln_Text_Var(", value:", gen.items[i2].genAmount.UAmount);
         }
-#endif
+ #endif
     }
-#pragma endregion
+// #pragma endregion
 }

--- a/src/sf22aswt_reader_base.h
+++ b/src/sf22aswt_reader_base.h
@@ -104,7 +104,7 @@ namespace SF22ASWT
 
         void FreePrevSampleData();
 
-#pragma region gen_get_functions
+// #pragma region gen_get_functions
         bool get_parameter_value(bag_of_gens* bags, int sampleIndex, SFGenerator genType, SF2GeneratorAmount *amount);
         float get_decibel_value(bag_of_gens* bags, int sampleIndex, SFGenerator genType, float DEFAULT, float MIN, float MAX);
         float get_timecents_value(bag_of_gens* bags, int sampleIndex, SFGenerator genType, float DEFAULT, float MIN);
@@ -119,7 +119,7 @@ namespace SF22ASWT
         int get_length(bag_of_gens* bags, int sampleIndex, shdr_rec &shdr);
         int get_key_range_end(bag_of_gens* bags, int sampleIndex);
         int get_length_bits(int len);
-#pragma endregion
+// #pragma endregion
         void DebugPrintBagContents(bag_of_gens &gen);
     };
 };

--- a/src/sf22aswt_reader_lazy.cpp
+++ b/src/sf22aswt_reader_lazy.cpp
@@ -7,7 +7,7 @@
 
 namespace SF22ASWT
 {
-    bool ReaderLazy::CloneInto(ReaderLazy &other)
+    CODE_LOCATION bool ReaderLazy::CloneInto(ReaderLazy &other)
     {
         if (lastReadWasOK == false) return false;
         other.lastReadWasOK = true;
@@ -16,7 +16,8 @@ namespace SF22ASWT
         sfbk.CloneInto(other.sfbk);
         return true;
     }
-    bool ReaderLazy::ReadFile(const char * filePath)
+
+    CODE_LOCATION bool ReaderLazy::ReadFile(const char * filePath)
     {
         lastReadWasOK = false;
         clearErrors();
@@ -90,7 +91,7 @@ namespace SF22ASWT
         return true;
     }
 
-    bool ReaderLazy::PrintInstrumentListAsJson(Print &printStream)
+    CODE_LOCATION bool ReaderLazy::PrintInstrumentListAsJson(Print &printStream)
     {
         clearErrors();
         if (lastReadWasOK == false) { lastError = SF22ASWT::Errors::FILE_NOT_OPEN; return false; }
@@ -115,7 +116,7 @@ namespace SF22ASWT
         return true;
     }
 
-    bool ReaderLazy::PrintPresetListAsJson(Print &printStream)
+    CODE_LOCATION bool ReaderLazy::PrintPresetListAsJson(Print &printStream)
     {
         clearErrors();
         if (lastReadWasOK == false) { lastError = SF22ASWT::Errors::FILE_NOT_OPEN; return false; }
@@ -146,7 +147,7 @@ namespace SF22ASWT
         return true;
     }
 
-    bool ReaderLazy::Load_instrument_data(uint index, SF22ASWT::instrument_data_temp &inst)
+    CODE_LOCATION bool ReaderLazy::Load_instrument_data(uint index, SF22ASWT::instrument_data_temp &inst)
     {
         clearErrors();
         if (lastReadWasOK == false) { lastError = SF22ASWT::Errors::FILE_NOT_OPEN; return false; }
@@ -245,7 +246,7 @@ namespace SF22ASWT
         return true;
     }
 
-    bool ReaderLazy::fillBagsOfGens(File &file, bag_of_gens* bags, int ibag_startIndex, int ibag_count)
+    CODE_LOCATION bool ReaderLazy::fillBagsOfGens(File &file, bag_of_gens* bags, int ibag_startIndex, int ibag_count)
     {
         uint32_t seekPos = sfbk.pdta.ibag_position + bag_rec::Size*ibag_startIndex;
         if (file.seek(seekPos) == false) FILE_SEEK_ERROR(PDTA_IBAG_DATA_SEEK, seekPos) //seek error to ibags
@@ -281,7 +282,7 @@ namespace SF22ASWT
         return true;
     }
 
-    bool ReaderLazy::Load_instrument_from_file(const char * filePath, int instrumentIndex, AudioSynthWavetable::instrument_data **aswt_id, Print &errPrintStream)
+    CODE_LOCATION bool ReaderLazy::Load_instrument_from_file(const char * filePath, int instrumentIndex, AudioSynthWavetable::instrument_data **aswt_id, Print &errPrintStream)
     {
         
         if (ReadFile(filePath) == false)
@@ -315,7 +316,7 @@ namespace SF22ASWT
         return true;
     }
 
-    bool ReaderLazy::Load_instrument(int instrumentIndex, AudioSynthWavetable::instrument_data*& aswt_id, Print &errPrintStream)
+    CODE_LOCATION bool ReaderLazy::Load_instrument(int instrumentIndex, AudioSynthWavetable::instrument_data*& aswt_id, Print &errPrintStream)
     {
         SF22ASWT::instrument_data_temp inst_temp = {0,0,nullptr};
 
@@ -341,7 +342,7 @@ namespace SF22ASWT
         return true;
     }
 
-    bool ReaderLazy::PrintInfoBlock(Print &printStream)
+    CODE_LOCATION bool ReaderLazy::PrintInfoBlock(Print &printStream)
     {
         clearErrors();
         if (lastReadWasOK == false) { lastError = SF22ASWT::Errors::FILE_NOT_OPEN; return false; }
@@ -358,7 +359,7 @@ namespace SF22ASWT
         return true;
     }
 
-    bool ReaderLazy::read_pdta_block(File &file, pdta_rec_lazy &pdta)
+    CODE_LOCATION bool ReaderLazy::read_pdta_block(File &file, pdta_rec_lazy &pdta)
     {
         char fourCC[4];
         uint32_t size = 0;

--- a/src/sf22aswt_reader_lazy.h
+++ b/src/sf22aswt_reader_lazy.h
@@ -23,6 +23,7 @@ namespace SF22ASWT
          *  all used blocks are stored into ram
          */
         bool ReadFile(const char * filePath);
+        bool ProcessInstrumentList(void (*callback)(SF22ASWT::inst_rec& inst, void* params), void* params);
         bool PrintInstrumentListAsJson(Print &printStream);
         bool PrintPresetListAsJson(Print &printStream);
         /**

--- a/src/sf22aswt_settings.h
+++ b/src/sf22aswt_settings.h
@@ -1,0 +1,9 @@
+#pragma once
+
+// this mode takes 448 bytes of flash
+#define SF22ASWT_PRINT_ERROR_CODE_AS_TEXT
+
+// Save RAM1 by putting code in Flash
+// Seems to increase the Flash, for some reason...
+#define CODE_LOCATION FLASHMEM
+//#define CODE_LOCATION

--- a/src/sf22aswt_settings.h
+++ b/src/sf22aswt_settings.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // this mode takes 448 bytes of flash
-#define SF22ASWT_PRINT_ERROR_CODE_AS_TEXT
+//#define SF22ASWT_PRINT_ERROR_CODE_AS_TEXT
 
 // Save RAM1 by putting code in Flash
 // Seems to increase the Flash, for some reason...

--- a/src/sf22aswt_structures.cpp
+++ b/src/sf22aswt_structures.cpp
@@ -4,7 +4,7 @@
 
 namespace SF22ASWT
 {
-    void sample_header_temp::PrintTo(Print &stream)
+    CODE_LOCATION void sample_header_temp::PrintTo(Print &stream)
     {
         stream.print("Sample Start:"); stream.print(sample_start);
         stream.print("\n, LOOP:"); stream.print(LOOP);
@@ -37,7 +37,7 @@ namespace SF22ASWT
         stream.print("\n, MOD_AMP_SCND_GAIN:"); stream.print(MOD_AMP_SCND_GAIN);
     }
 
-    void instrument_data_temp::PrintTo(Print &stream)
+    CODE_LOCATION void instrument_data_temp::PrintTo(Print &stream)
     {
         stream.print("Sample Count: "); stream.print(sample_count);
         stream.print("\n");
@@ -50,7 +50,7 @@ namespace SF22ASWT
         }
     }
 
-    void sfVersionTag::PrintTo(Print &stream)
+    CODE_LOCATION void sfVersionTag::PrintTo(Print &stream)
     {
         stream.print(major);
         stream.print(".");
@@ -58,7 +58,7 @@ namespace SF22ASWT
         stream.print(minor);
     }
 
-    void INFO::PrintTo(Print &stream)
+    CODE_LOCATION void INFO::PrintTo(Print &stream)
     {
         stream.println();
         stream.print("*** Info *** ( size: ");
@@ -77,7 +77,7 @@ namespace SF22ASWT
         stream.print("Tools: "); stream.println(ISFT);
     }
 
-    pdta_rec::pdta_rec()
+    CODE_LOCATION pdta_rec::pdta_rec()
     {
         phdr = new phdr_rec[0];
         pbag = new bag_rec[0];
@@ -90,7 +90,7 @@ namespace SF22ASWT
         shdr = new shdr_rec[0];
     }
 
-    void pdta_rec_lazy::CloneInto(pdta_rec_lazy &other)
+    CODE_LOCATION void pdta_rec_lazy::CloneInto(pdta_rec_lazy &other)
     {
         other.size = size;
         other.ibag_count = ibag_count;
@@ -113,20 +113,20 @@ namespace SF22ASWT
         other.shdr_position = shdr_position;
     }
 
-    void smpl_rec::CloneInto(smpl_rec &other)
+    CODE_LOCATION void smpl_rec::CloneInto(smpl_rec &other)
     {
         other.size = size;
         other.position = position;
     }
 
-    void sdta_rec_lazy::CloneInto(sdta_rec_lazy &other)
+    CODE_LOCATION void sdta_rec_lazy::CloneInto(sdta_rec_lazy &other)
     {
         other.size = size;
         smpl.CloneInto(other.smpl);
         sm24.CloneInto(other.sm24);
     }
 
-    void sfbk_rec_lazy::CloneInto(sfbk_rec_lazy &other)
+    CODE_LOCATION void sfbk_rec_lazy::CloneInto(sfbk_rec_lazy &other)
     {
         other.size = size;
         other.info_position = info_position;

--- a/src/sf22aswt_structures.h
+++ b/src/sf22aswt_structures.h
@@ -3,6 +3,7 @@
 
 #include <Arduino.h>
 #include "sf22aswt_enums.h"
+#include "sf22aswt_settings.h"
 
 
 /**


### PR DESCRIPTION
A few minor modifications:

- define and use a `CODE_LOCATION` macro which allows forcing the code into FLASHMEM to save RAM1 space in big projects (which mine is!)
- comment the `#pragma region` lines - they seem to work just as well, but GCC doesn't cause a warning (which due to a bug in GCC can't be turned off...)
- add the `ProcessInstrumentList` method, and use it for the `PrintInstrumentListAsJson` method; the user application can make use of this to create e.g. a std::vector of the available instruments in a file

Oh, and the text-based error outputs weren't working - I fixed those