### PR TITLE
Fix progressive sharpening from PER_HERTZ_PHASE_INCREMENT

### DIFF
--- a/src/sf22aswt_converter.cpp
+++ b/src/sf22aswt_converter.cpp
@@ -33,7 +33,7 @@ namespace SF22ASWT::converter
             (int16_t*)sd.sample,
             sd.LOOP, // LOOP
             sd.LENGTH_BITS, // LENGTH_BITS
-            (float)((1 << (32 - sd.LENGTH_BITS)) * WAVETABLE_CENTS_SHIFT(sd.CENTS_OFFSET) * sd.SAMPLE_RATE / WAVETABLE_NOTE_TO_FREQUENCY(sd.SAMPLE_NOTE) / AUDIO_SAMPLE_RATE_EXACT + 0.5f), // PER_HERTZ_PHASE_INCREMENT
+            (float)((1 << (32 - sd.LENGTH_BITS)) * WAVETABLE_CENTS_SHIFT(sd.CENTS_OFFSET) * sd.SAMPLE_RATE / WAVETABLE_NOTE_TO_FREQUENCY(sd.SAMPLE_NOTE) / AUDIO_SAMPLE_RATE_EXACT), // PER_HERTZ_PHASE_INCREMENT
             ((uint32_t)sd.LENGTH - 1) << (32 - sd.LENGTH_BITS), // MAX_PHASE
             ((uint32_t)sd.LOOP_END - 1) << (32 - sd.LENGTH_BITS), // LOOP_PHASE_END
             (((uint32_t)sd.LOOP_END - 1) << (32 - sd.LENGTH_BITS)) - (((uint32_t)sd.LOOP_START - 1) << (32 - sd.LENGTH_BITS)), // LOOP_PHASE_LENGTH


### PR DESCRIPTION

The converter computes `PER_HERTZ_PHASE_INCREMENT` and stores it as `float` (see `AudioSynthWavetable::sample_data` in `synth_wavetable.h`). The trailing `+ 0.5f` in `toFinal()` is correct for the that casts to `uint32_t` (`DELAY_COUNT`, `ATTACK_COUNT`, etc.) — but here the cast is `(float)`, so it just adds a literal 0.5 to the per-Hz phase increment.

At play time the engine multiplies by the played frequency:
`  tone_incr = freq * PER_HERTZ_PHASE_INCREMENT`
so every note picks up an extra phase of `0.5*freq` per output sample. The resulting pitch ratio at the root note is `1 + 0.5/per_hertz_true`, and since `per_hertz_true` is inversely proportional to root frequency, the cents error grows linearly with the played frequency. Symptom: notes get progressively sharper as you go up the keyboard.

The error is also proportional to sample length. I happened to be using some 6s samples, so at MIDI 73, playback was a full quarter-step sharp.